### PR TITLE
feat: wire open5e and 5etools source types into MCP tools and manager

### DIFF
--- a/src/dm20_protocol/main.py
+++ b/src/dm20_protocol/main.py
@@ -1300,8 +1300,8 @@ def get_events(
 @mcp.tool
 async def load_rulebook(
     source: Annotated[
-        Literal["srd", "custom"],
-        Field(description="Source type: 'srd' for official D&D 5e SRD, 'custom' for local files")
+        Literal["srd", "custom", "open5e", "5etools"],
+        Field(description="Source type: 'srd' for official D&D 5e SRD, 'custom' for local files, 'open5e' for Open5e API, '5etools' for 5etools JSON data")
     ],
     version: Annotated[
         str | None,
@@ -1328,6 +1328,20 @@ async def load_rulebook(
         counts = srd_source.content_counts()
         return f"✅ Loaded SRD {version} rulebook\n📚 {counts.classes} classes, {counts.races} races, {counts.spells} spells, {counts.monsters} monsters"
 
+    elif source == "open5e":
+        from .rulebooks.sources.open5e import Open5eSource
+        open5e_source = Open5eSource(cache_dir=storage.rulebook_cache_dir)
+        await storage.rulebook_manager.load_source(open5e_source)
+        counts = open5e_source.content_counts()
+        return f"✅ Loaded Open5e rulebook\n📚 {counts.classes} classes, {counts.races} races, {counts.spells} spells, {counts.monsters} monsters"
+
+    elif source == "5etools":
+        from .rulebooks.sources.fivetools import FiveToolsSource
+        fivetools_source = FiveToolsSource(cache_dir=storage.rulebook_cache_dir)
+        await storage.rulebook_manager.load_source(fivetools_source)
+        counts = fivetools_source.content_counts()
+        return f"✅ Loaded 5etools rulebook\n📚 {counts.classes} classes, {counts.races} races, {counts.spells} spells, {counts.monsters} monsters"
+
     elif source == "custom":
         if not path:
             return "❌ Custom source requires 'path' parameter"
@@ -1337,7 +1351,7 @@ async def load_rulebook(
         counts = custom_source.content_counts()
         return f"✅ Loaded custom rulebook: {path}\n📚 {counts.classes} classes, {counts.races} races, {counts.spells} spells"
 
-    return "❌ Invalid source type. Use 'srd' or 'custom'."
+    return "❌ Invalid source type. Use 'srd', 'custom', 'open5e', or '5etools'."
 
 @mcp.tool
 def list_rulebooks() -> str:

--- a/src/dm20_protocol/rulebooks/manager.py
+++ b/src/dm20_protocol/rulebooks/manager.py
@@ -46,7 +46,7 @@ class RulebookManagerError(Exception):
 class SourceConfig:
     """Configuration for a loaded source."""
     id: str
-    type: str  # "srd" or "custom"
+    type: str  # "srd", "custom", "open5e", or "5etools"
     loaded_at: str  # ISO timestamp
     version: str | None = None  # For SRD sources
     path: str | None = None  # For custom sources
@@ -457,13 +457,24 @@ class RulebookManager:
         )
 
         if source.source_type == RulebookSourceEnum.SRD:
-            # SRD source
             version = getattr(source, "version", "2014")
             return SourceConfig(
                 id=source.source_id,
                 type="srd",
                 loaded_at=loaded_at,
                 version=version,
+            )
+        elif source.source_type == RulebookSourceEnum.OPEN5E:
+            return SourceConfig(
+                id=source.source_id,
+                type="open5e",
+                loaded_at=loaded_at,
+            )
+        elif source.source_type == RulebookSourceEnum.FIVETOOLS:
+            return SourceConfig(
+                id=source.source_id,
+                type="5etools",
+                loaded_at=loaded_at,
             )
         else:
             # Custom source
@@ -543,6 +554,18 @@ class RulebookManager:
 
             cache_dir = self._manifest_dir / "cache" if self._manifest_dir else None
             return SRDSource(version=config.version or "2014", cache_dir=cache_dir)
+
+        elif config.type == "open5e":
+            from .sources.open5e import Open5eSource
+
+            cache_dir = self._manifest_dir / "cache" if self._manifest_dir else None
+            return Open5eSource(cache_dir=cache_dir)
+
+        elif config.type == "5etools":
+            from .sources.fivetools import FiveToolsSource
+
+            cache_dir = self._manifest_dir / "cache" if self._manifest_dir else None
+            return FiveToolsSource(cache_dir=cache_dir)
 
         elif config.type == "custom":
             from .sources.custom import CustomSource

--- a/src/dm20_protocol/rulebooks/models.py
+++ b/src/dm20_protocol/rulebooks/models.py
@@ -21,6 +21,7 @@ class RulebookSource(str, Enum):
     SRD = "srd"
     OPEN5E = "open5e"
     CUSTOM = "custom"
+    FIVETOOLS = "5etools"
 
 
 class Size(str, Enum):


### PR DESCRIPTION
## Summary
- Extended `load_rulebook` MCP tool to accept `"open5e"` and `"5etools"` source types
- Added `FIVETOOLS = "5etools"` to `RulebookSource` enum in `models.py`
- Added factory branches in `RulebookManager._create_source_from_config()` and `_source_to_config()` for both new source types
- Uses lazy imports (same pattern as existing SRD/Custom sources)

## Test plan
- [x] All 109 existing rulebook and MCP tests pass unchanged
- [ ] End-to-end `load_rulebook(source="open5e")` works (requires #81)
- [ ] End-to-end `load_rulebook(source="5etools")` works (requires #83/#84)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)